### PR TITLE
Adding possible workaround for problems with Qt QEvent::Tablet(Enter|…

### DIFF
--- a/src/client/docks/toolsettingsdock.cpp
+++ b/src/client/docks/toolsettingsdock.cpp
@@ -34,7 +34,7 @@
 namespace docks {
 
 ToolSettings::ToolSettings(QWidget *parent)
-	: QDockWidget(parent), _currentQuickslot(0), _eraserOverride(0)
+	: QDockWidget(parent), _currentQuickslot(0), _eraserOverride(0), _eraserActive(false)
 {
 	// Initialize tool slots
 	_toolprops.reserve(QUICK_SLOTS);
@@ -404,11 +404,13 @@ void ToolSettings::saveCurrentTool()
 
 void ToolSettings::eraserNear(bool near)
 {
-	if(near) {
+	if(near && !_eraserActive) {
 		_eraserOverride = currentTool();
 		setTool(tools::ERASER);
-	} else {
+		_eraserActive = true;
+	} else if(!near && _eraserActive) {
 		setTool(tools::Type(_eraserOverride));
+		_eraserActive = false;
 	}
 }
 

--- a/src/client/docks/toolsettingsdock.h
+++ b/src/client/docks/toolsettingsdock.h
@@ -196,6 +196,8 @@ private:
 	widgets::ToolSlotButton *_quickslot[QUICK_SLOTS];
 	int _currentQuickslot;
 	int _eraserOverride;
+	bool _eraserActive;
+
 	QList<tools::ToolsetProperties> _toolprops;
 
 	tools::Type _previousTool;

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -77,9 +77,17 @@ DrawpileApp::DrawpileApp(int &argc, char **argv)
 bool DrawpileApp::event(QEvent *e) {
 	if(e->type() == QEvent::TabletEnterProximity || e->type() == QEvent::TabletLeaveProximity) {
 		QTabletEvent *te = static_cast<QTabletEvent*>(e);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
 		if(te->pointerType()==QTabletEvent::Eraser)
 			emit eraserNear(e->type() == QEvent::TabletEnterProximity);
-
+#else
+		if(e->type() == QEvent::TabletEnterProximity) {
+			if(te->pointerType()==QTabletEvent::Eraser)
+				emit eraserNear(true);
+			else
+				emit eraserNear(false);
+		}
+#endif
 		return true;
 
 	} else if(e->type() == QEvent::FileOpen) {


### PR DESCRIPTION
…Leave)Proximity events.

I still found behaviour similar Issue #100 under Linux after recompiling Drawpile against Qt5.4.1. It seems that after clicking something in the menu, like you described in issue #100, Drawpile sees Enter and Leave events two times, instead of the Enter Leave combination under prior Qt Versions.
When this happens the actual tool gets overwritten by the eraser tool.

I tried to workaround that by tracking if the Eraser was selected that way and only changing state if it was/wasn't selected before.
For Qt versions prior to 5.4 the switching does work if one only reacts to the EnterProximity event from eraser and pen. With the minor drawback that the eraser tool stays active until you bring the pen tip in proximity of the tablet again.
