### PR TITLE
Remove starting lag from smoothed strokes

### DIFF
--- a/src/client/scene/canvasview.cpp
+++ b/src/client/scene/canvasview.cpp
@@ -437,8 +437,7 @@ void CanvasView::onPenDown(const paintcore::Point &p, bool right)
 		} else {
 			if(_smoothing>0 && _current_tool->allowSmoothing())
 				_smoother.addPoint(p);
-			else
-				_current_tool->begin(p, right, _zoom);
+			_current_tool->begin(p, right, _zoom);
 		}
 	}
 }
@@ -453,10 +452,7 @@ void CanvasView::onPenMove(const paintcore::Point &p, bool right, bool shift, bo
 			if(_smoothing>0 && _current_tool->allowSmoothing()) {
 				_smoother.addPoint(p);
 				if(_smoother.hasSmoothPoint()) {
-					if(_smoother.isFirstSmoothPoint())
-						_current_tool->begin(_smoother.smoothPoint(), right, _zoom);
-					else
-						_current_tool->motion(_smoother.smoothPoint(), shift, alt);
+					_current_tool->motion(_smoother.smoothPoint(), shift, alt);
 				}
 			} else {
 				_current_tool->motion(p, shift, alt);
@@ -469,10 +465,6 @@ void CanvasView::onPenUp(bool right)
 {
 	if(_scene->hasImage() && !_locked) {
 		if(!_specialpenmode) {
-			// Add the missing single dab when smoothing is used
-			if(_smoothing>0 && _current_tool->allowSmoothing() && !_smoother.hasSmoothPoint()) {
-				_current_tool->begin(_smoother.latestPoint(), right, _zoom);
-			}
 			_current_tool->end();
 		}
 

--- a/src/client/scene/canvasview.cpp
+++ b/src/client/scene/canvasview.cpp
@@ -454,6 +454,10 @@ void CanvasView::onPenMove(const paintcore::Point &p, bool right, bool shift, bo
 				if(_smoother.hasSmoothPoint()) {
 					_current_tool->motion(_smoother.smoothPoint(), shift, alt);
 				}
+				// Remember the keys in use in case we simulate
+				// catch-up moves on pen up
+				_prevshift = shift;
+				_prevalt = alt;
 			} else {
 				_current_tool->motion(p, shift, alt);
 			}
@@ -465,6 +469,15 @@ void CanvasView::onPenUp(bool right)
 {
 	if(_scene->hasImage() && !_locked) {
 		if(!_specialpenmode) {
+			// Drain any remaining points from the smoothing buffer
+			if(_smoother.hasSmoothPoint())
+				_smoother.removePoint();
+			while(_smoother.hasSmoothPoint()) {
+				_current_tool->motion(_smoother.smoothPoint(),
+					_prevshift, _prevalt);
+				_smoother.removePoint();
+			}
+
 			_current_tool->end();
 		}
 

--- a/src/client/scene/canvasview.h
+++ b/src/client/scene/canvasview.h
@@ -260,6 +260,8 @@ class CanvasView : public QGraphicsView
 		float _pointerdistance;
 		float _pointervelocity;
 		StrokeSmoother _smoother;
+		bool _prevshift;
+		bool _prevalt;
 
 		qreal _gestureStartZoom;
 		qreal _gestureStartAngle;

--- a/src/client/utils/strokesmoother.cpp
+++ b/src/client/utils/strokesmoother.cpp
@@ -34,12 +34,16 @@ void StrokeSmoother::addPoint(const paintcore::Point &point)
 {
 	Q_ASSERT(_points.size()>0);
 
-	if(--_pos < 0)
-		_pos = _points.size()-1;
-	_points[_pos] = point;
-
-	if(_count < _points.size())
-		++_count;
+	if(_count == 0) {
+		// Pad the buffer with this point, so we blend away from it
+		// gradually as we gain more points.
+		_points.fill(point);
+		_count = _points.size();
+	} else {
+		if(--_pos < 0)
+			_pos = _points.size()-1;
+		_points[_pos] = point;
+	}
 }
 
 paintcore::Point StrokeSmoother::at(int i) const

--- a/src/client/utils/strokesmoother.cpp
+++ b/src/client/utils/strokesmoother.cpp
@@ -55,7 +55,7 @@ void StrokeSmoother::reset()
 
 bool StrokeSmoother::hasSmoothPoint() const
 {
-	return _count == _points.size();
+	return _count > 0;
 }
 
 paintcore::Point StrokeSmoother::smoothPoint() const

--- a/src/client/utils/strokesmoother.cpp
+++ b/src/client/utils/strokesmoother.cpp
@@ -33,7 +33,6 @@ void StrokeSmoother::setSmoothing(int strength)
 void StrokeSmoother::addPoint(const paintcore::Point &point)
 {
 	Q_ASSERT(_points.size()>0);
-	bool hadSmooth = hasSmoothPoint();
 
 	if(--_pos < 0)
 		_pos = _points.size()-1;
@@ -41,8 +40,6 @@ void StrokeSmoother::addPoint(const paintcore::Point &point)
 
 	if(_count < _points.size())
 		++_count;
-
-	_firstsmooth = !hadSmooth && hasSmoothPoint();
 }
 
 paintcore::Point StrokeSmoother::at(int i) const
@@ -54,7 +51,6 @@ void StrokeSmoother::reset()
 {
 	_count=0;
 	_pos = 0;
-	_firstsmooth = false;
 }
 
 bool StrokeSmoother::hasSmoothPoint() const

--- a/src/client/utils/strokesmoother.h
+++ b/src/client/utils/strokesmoother.h
@@ -56,13 +56,6 @@ public:
 	bool hasSmoothPoint() const;
 
 	/**
-	 * @brief Is this the first available smoothed point
-	 *
-	 * @return true if this is the first smoothed point
-	 */
-	bool isFirstSmoothPoint() const { return _firstsmooth; }
-
-	/**
 	 * @brief Get the smoothed point
 	 *
 	 * @return smoothed point
@@ -70,19 +63,12 @@ public:
 	 */
 	paintcore::Point smoothPoint() const;
 
-	/**
-	 * @brief Get the last point added to the smoother
-	 * @return
-	 */
-	paintcore::Point latestPoint() const { return at(0); }
-
 private:
 	paintcore::Point at(int i) const;
 
 	QVector<paintcore::Point> _points;
 	int _pos;
 	int _count;
-	bool _firstsmooth;
 };
 
 #endif // STROKESMOOTHER_H

--- a/src/client/utils/strokesmoother.h
+++ b/src/client/utils/strokesmoother.h
@@ -63,12 +63,25 @@ public:
 	 */
 	paintcore::Point smoothPoint() const;
 
+	/**
+	 * @brief Remove one point from the buffer, for ending a line
+	 *
+	 * @pre hasSmoothPoint() == true
+	 */
+	void removePoint();
+
+	/**
+	 * @brief Get the last point added to the smoother
+	 * @return
+	 */
+	paintcore::Point latestPoint() const { return at(0); }
+
 private:
 	paintcore::Point at(int i) const;
 
 	QVector<paintcore::Point> _points;
 	int _pos;
-	int _count;
+	int _count; ///< Number of actually sampled points in the buffer
 };
 
 #endif // STROKESMOOTHER_H


### PR DESCRIPTION
The current smoother causes a pretty nasty positional lag to the start of strokes, which makes it hard to accurately position them to connect with other strokes, e.g. drawing a set of lines radiating from a central point.

Have smoothing effectively start at zero and ramp up as more points become available so strokes start where the cursor first touches down.

Partially relates to #179, but the smoother is still just a plain unweighted average.

(I think in future it might be worth looking at having the smoother buffer up some move events so it can still use as many points as possible, but cause *temporal* lag instead, e.g. when you have a full buffer suddenly canvasview can drain that many moves from the smoother, after which it is back to one point added, one (lagged) move received.)