### PR TITLE
Dockerised Drawpile Server definition

### DIFF
--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:15.04
+RUN apt-get update \
+ && apt-get install \
+    wget \
+    cmake \
+    make \
+    qtbase5-dev \
+    libkf5archive-dev \
+    g++ \
+    qtm \
+    qtmultimedia5-dev \
+    libqt5svg5-dev \
+    libgif-dev \
+    libkf5dnssd-dev \
+    -y \
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+ENV VERSION 1.0.2
+
+RUN wget http://drawpile.net/files/src/drawpile-$VERSION.tar.gz \
+ && tar -xf drawpile-$VERSION.tar.gz \
+ && cd drawpile-$VERSION \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install
+
+RUN cd / && rm -rf /drawpile-*
+RUN useradd -m drawpile
+USER drawpile
+EXPOSE 8080
+CMD drawpile-srv --persistent --listen 0.0.0.0 --port 8080 --verbose --title "Docker Drawpile"

--- a/server/docker/README.md
+++ b/server/docker/README.md
@@ -1,0 +1,17 @@
+# Docker Drawpile
+
+Docker is a way to easily package applications into shippable 'containers'
+which can be run on any server running a docker container. 
+
+This directory contains the Dockerfile defintion for creating a drawpile
+server from docker. 
+
+To build, simply run the following commands:
+
+`docker build -t drawpile .`
+
+And to run:
+
+`docker run --daemonize --tty -p 8080:8080 drawpile` 
+
+This will start a drawpile server running on port 8080

--- a/server/docker/README.md
+++ b/server/docker/README.md
@@ -1,17 +1,20 @@
 # Docker Drawpile
 
-Docker is a way to easily package applications into shippable 'containers'
-which can be run on any server running a docker container. 
+[Docker](https://www.docker.com/) is a way to easily package applications into shippable 'containers'. This directory 
+contains the Dockerfile defintion for creating a drawpile server. 
 
-This directory contains the Dockerfile defintion for creating a drawpile
-server from docker. 
+To build, simply run the following command in this directory:
 
-To build, simply run the following commands:
+```
+docker build -t drawpile .
+```
 
-`docker build -t drawpile .`
+Which will download and compile the latest Drawpile server. At the end of this process you will have a Docker container image ready to be run.
 
-And to run:
+To run the your Drawpile docker container, simply use the following command:
 
-`docker run --daemonize --tty -p 8080:8080 drawpile` 
+```
+docker run --detach --tty --name drawpile -p 8080:8080 drawpile
+``` 
 
-This will start a drawpile server running on port 8080
+This will start a drawpile server in the background running on port 8080. 


### PR DESCRIPTION
One of the things which I found painful during the setup of a drawpile server was the amount of dependencies I needed to install to get a dedicated `drawpile-srv` up and running. 

To make things more accessible, I've created a [Docker](https://www.docker.com/) spec for `drawpile-srv`. This will reduce the amount of setup a developer/potential hoster needs to something like `docker run --daemonize -p 8080:8080 drawpile` (it's trivial to host the build spec on [Docker Hub](https://hub.docker.com/) and have it build the container automatically, available for people to host as they want).

Below is an example of me running a drawpile server on a hastily spun up AWS vm. Total time between me starting this VM and getting drawpile up and running: <5mins.

![Drawpile on Docker containers](http://i.imgur.com/8YYm6ug.png)
