### PR TITLE
actually sort sessions by UserRole rather than DisplayRole

### DIFF
--- a/src/client/dialogs/sessionlistingdialog.cpp
+++ b/src/client/dialogs/sessionlistingdialog.cpp
@@ -83,6 +83,7 @@ SessionListingDialog::SessionListingDialog(QWidget *parent)
 	_model->setSourceModel(_sessions);
 	_model->setFilterCaseSensitivity(Qt::CaseInsensitive);
 	_model->setFilterKeyColumn(-1);
+	_model->setSortRole(Qt::UserRole);
 
 	connect(_ui->filter, &QLineEdit::textChanged, _model, &QSortFilterProxyModel::setFilterFixedString);
 


### PR DESCRIPTION
This is what sessionlistingmodel.cpp claims is already the case,
but the default value is actually DisplayRole.